### PR TITLE
Fix go vet warnings

### DIFF
--- a/ch4/treesort/sort_test.go
+++ b/ch4/treesort/sort_test.go
@@ -18,6 +18,6 @@ func TestSort(t *testing.T) {
 	}
 	treesort.Sort(data)
 	if !sort.IntsAreSorted(data) {
-		t.Errorf("not sorted: %s", data)
+		t.Errorf("not sorted: %v", data)
 	}
 }

--- a/ch7/eval/eval_test.go
+++ b/ch7/eval/eval_test.go
@@ -43,7 +43,7 @@ func TestEval(t *testing.T) {
 		got := fmt.Sprintf("%.6g", expr.Eval(test.env))
 		fmt.Printf("\t%v => %s\n", test.env, got)
 		if got != test.want {
-			t.Errorf("%s.Eval() in %s = %q, want %q\n",
+			t.Errorf("%s.Eval() in %v = %q, want %q\n",
 				test.expr, test.env, got, test.want)
 		}
 	}

--- a/ch7/eval/parse.go
+++ b/ch7/eval/parse.go
@@ -130,7 +130,7 @@ func parsePrimary(lex *lexer) Expr {
 				lex.next() // consume ','
 			}
 			if lex.token != ')' {
-				msg := fmt.Sprintf("got %s, want ')'", lex.token)
+				msg := fmt.Sprintf("got %#U, want ')'", lex.token)
 				panic(lexPanic(msg))
 			}
 		}


### PR DESCRIPTION
```
% go vet ./...
ch4/treesort/sort_test.go:21: arg data for printf verb %s of wrong type:
[]int
exit status 1

ch7/eval/parse.go:133: arg lex.token for printf verb %s of wrong type:
rune

ch7/eval/eval_test.go:46: arg test.env for printf verb %s of wrong type:
eval.Env
exit status 1
```
