### PR TITLE
Fix wrong complexity of algorithm in comment

### DIFF
--- a/ch4/append/main.go
+++ b/ch4/append/main.go
@@ -37,7 +37,7 @@ func appendInt(x []int, y int) []int {
 		z = x[:zlen]
 	} else {
 		// There is insufficient space.  Allocate a new array.
-		// Grow by doubling, for amortized linear complexity.
+		// Grow by doubling, for amortized constant time complexity.
 		zcap := zlen
 		if zcap < 2*len(x) {
 			zcap = 2 * len(x)


### PR DESCRIPTION
The func appendInt(...) function takes constant time on average to append an element to a slice. The comment incorrectly suggests that the algorithm amortizes to linear time complexity.
