### PR TITLE
Set `err` only when an error occurs.

### DIFF
--- a/ch5/fetch/main.go
+++ b/ch5/fetch/main.go
@@ -34,7 +34,7 @@ func fetch(url string) (filename string, n int64, err error) {
 	}
 	n, err = io.Copy(f, resp.Body)
 	// Close file, but prefer error from Copy, if any.
-	if closeErr := f.Close(); err == nil {
+	if closeErr := f.Close(); closeErr != nil && err == nil {
 		err = closeErr
 	}
 	return local, n, err


### PR DESCRIPTION
This code was confusing because it sets `err` even when `closeErr` is `nil`. The PR suggests a modification to clarify the behavior. Alternatively, perhaps adding a comment would be sufficient.