### PR TITLE
Fix url in ch1/server2 for counter

### DIFF
--- a/ch1/server2/main.go
+++ b/ch1/server2/main.go
@@ -19,7 +19,7 @@ var count int
 
 func main() {
 	http.HandleFunc("/", handler)
-	http.HandleFunc("/count", counter)
+	http.HandleFunc("/count/", counter)
 	log.Fatal(http.ListenAndServe("localhost:8000", nil))
 }
 


### PR DESCRIPTION
Navigating to `/count` should not increment the counter