### PR TITLE
Fix order of conversion characters

### DIFF
--- a/ch1/dup1/main.go
+++ b/ch1/dup1/main.go
@@ -23,7 +23,7 @@ func main() {
 	// NOTE: ignoring potential errors from input.Err()
 	for line, n := range counts {
 		if n > 1 {
-			fmt.Printf("%d\t%s\n", n, line)
+			fmt.Printf("%s\t%d\n", line, n)
 		}
 	}
 }

--- a/ch1/dup2/main.go
+++ b/ch1/dup2/main.go
@@ -32,7 +32,7 @@ func main() {
 	}
 	for line, n := range counts {
 		if n > 1 {
-			fmt.Printf("%d\t%s\n", n, line)
+			fmt.Printf("%s\t%d\n", line, n)
 		}
 	}
 }

--- a/ch1/dup3/main.go
+++ b/ch1/dup3/main.go
@@ -30,7 +30,7 @@ func main() {
 	}
 	for line, n := range counts {
 		if n > 1 {
-			fmt.Printf("%d\t%s\n", n, line)
+			fmt.Printf("%s\t%d\n", line, n)
 		}
 	}
 }


### PR DESCRIPTION
Fix order of conversion charachters `%d` and `%s` respectively in order to have a meaningful output when running `dup`. 