### PR TITLE
Duplicate text and count does not print

### DIFF
--- a/ch1/dup1/main.go
+++ b/ch1/dup1/main.go
@@ -19,11 +19,12 @@ func main() {
 	input := bufio.NewScanner(os.Stdin)
 	for input.Scan() {
 		counts[input.Text()]++
-	}
-	// NOTE: ignoring potential errors from input.Err()
-	for line, n := range counts {
-		if n > 1 {
-			fmt.Printf("%d\t%s\n", n, line)
+		
+		// NOTE: ignoring potential errors from input.Err()
+		for line, n := range counts {
+			if n > 1 {
+				fmt.Printf("%d\t%s\n", n, line)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This example does not appear to print the text and count to the console. For reference, I am using version 1.12.7 of the go language on osx. If the logic that iterates over the map of counts is moved inside the standard input scanner for loop then I receive the appropriate log statements.