### PR TITLE
Use *lexer.describe in parse error message

### DIFF
--- a/ch7/eval/parse.go
+++ b/ch7/eval/parse.go
@@ -130,7 +130,7 @@ func parsePrimary(lex *lexer) Expr {
 				lex.next() // consume ','
 			}
 			if lex.token != ')' {
-				msg := fmt.Sprintf("got %q, want ')'", lex.token)
+				msg := fmt.Sprintf("got %s, want ')'", lex.describe())
 				panic(lexPanic(msg))
 			}
 		}


### PR DESCRIPTION
Make error messages for tokens like EOF, Ident, Int or Float easier to
understand.

An example, without this change:

```
Invalid expression: got %!q(int32=-1), want ')'
```

With this change:

```
Invalid expression: got end of file, want ')'
```