### PR TITLE
ch1/dup1 : Break the scanner loop for empty input

### DIFF
--- a/ch1/dup1/main.go
+++ b/ch1/dup1/main.go
@@ -18,6 +18,9 @@ func main() {
 	counts := make(map[string]int)
 	input := bufio.NewScanner(os.Stdin)
 	for input.Scan() {
+		if len(input.Text()) == 0 {
+			break
+		}
 		counts[input.Text()]++
 	}
 	// NOTE: ignoring potential errors from input.Err()


### PR DESCRIPTION
Currently the existing [ch1/dup1](https://github.com/adonovan/gopl.io/blob/master/ch1/dup1/main.go) does not breaks for an empty input. Ctrl-C breaks the loop but ends in terminating the complete program.

The expected behavior should be that when there is an empty line as an input from user, the scanner loop should terminate.

## Issue Reproduced on MacOS
![image](https://user-images.githubusercontent.com/7676016/92945702-4361d200-f41b-11ea-8f07-1321594acf90.png)
