### PR TITLE
refactor: changing ioutil to io

### DIFF
--- a/ch1/fetch/main.go
+++ b/ch1/fetch/main.go
@@ -9,7 +9,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 )
@@ -21,7 +21,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "fetch: %v\n", err)
 			os.Exit(1)
 		}
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "fetch: reading %s: %v\n", url, err)


### PR DESCRIPTION
changing ioutil to io as io.ioutil is deprecated in Go1.16